### PR TITLE
#3 해쉬라우터

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css"
+      rel="stylesheet" />
+    <link href="./main.css" rel="stylesheet" />
     <script type="module" defer src="./src/main.js"></script>
   </head>
   <body>

--- a/main.css
+++ b/main.css
@@ -1,0 +1,13 @@
+router-view {
+  height: 3000px;
+  display: inline-block;
+  padding: 50px;
+}
+
+header {
+  position: fixed;
+  width: 100%;
+  height: 30px;
+  line-height: 2;
+  background-color: rgba(0, 0, 0, 0.1);
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,38 +1,12 @@
 import Component from './core/component.js'
-import FruitItem from './components/fruitItem.js';
+import Header from './components/header.js'
 
 export default class App extends Component {
-  constructor() {
-    super({
-      state: {
-        fruits: [
-          { name: 'Apple', price: 1000 },
-          { name: 'Cherry', price: 2000 },
-          { name: 'Strawberry', price: 3000 },
-          { name: 'Watermelon', price: 4000 },
-        ]
-      }
-    });
-  }
-
   render() {
-    this.el.innerHTML =/* html */ `
-      <h1>Fruits</h1>
-      <ul>
-        
-      </ul>
-  `
-    const ulEl = this.el.querySelector('ul');
-    ulEl.append(...
-      this.state.fruits
-        .filter(f => f.price < 4000)
-        .map(f => new FruitItem({
-          props: {
-            name: f.name,
-            price: f.price
-          }
-        }).el)
-    );
+    const routerView = document.createElement('router-view');
+    this.el.append(
+      new Header().el,
+      routerView
+    )
   }
-
 }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,0 +1,16 @@
+import Component from '../core/component.js';
+
+export default class Header extends Component {
+  constructor() {
+    super({
+      tagName: "header",
+    });
+  }
+
+  render() {
+    this.el.innerHTML = /* html */`
+      <a href="#/">Home</a>
+      <a href="#/about">About!</a>
+    `
+  }
+}

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -1,0 +1,29 @@
+// ROUTER
+export default function createRouter(pages) {
+  return function () {
+    window.addEventListener('popstate', () => {
+      routeRender(pages);
+    })
+    routeRender(pages);
+  }
+}
+
+function routeRender(pages) {
+  if (!location.hash) {
+    history.replaceState(null, '', '/#/')
+  }
+  const routeView = document.querySelector('router-view');
+  const [hash, queryString = ''] = location.hash.split("?");
+
+  const query = queryString.split("&").reduce((acc, cur) => {
+    const [key, value] = cur.split("=");
+    acc[key] = value;
+    return acc;
+  }, {});
+  history.replaceState(query, '');
+
+  const currentRoute = pages.find(page => new RegExp(`${page.path}/?$`).test(hash));
+  routeView.innerHTML = '';
+  routeView.append(new currentRoute.component().el);
+  window.scrollTo(0, 0);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,10 @@
 import App from "./app.js"
+import router from './pages'
 
 const root = document.querySelector("#root");
 root.append(new App().el);
 console.log("hello")
+
+router();
+
+

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,0 +1,10 @@
+import Component from '../core/component.js';
+
+export default class About extends Component {
+
+  render() {
+    this.el.innerHTML = /*html*/ `
+      <h1>About !!!!!!!</h1>
+    `
+  }
+}

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,0 +1,13 @@
+import Component from '../core/component.js';
+import TextField from '../components/textField.js';
+import Message from '../components/message.js';
+
+export default class Home extends Component {
+
+  render() {
+    this.el.innerHTML = /*html*/ `
+      <h1>HOME PAGE!!!!!!!</h1>
+    `;
+
+  }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,8 @@
+import Home from './home.js'
+import About from './about.js'
+import createRouter from '../core/router.js'
+
+export default createRouter([
+  { path: '#/', component: Home },
+  { path: '#/about', component: About },
+]);


### PR DESCRIPTION
페이지정보인 라우트를 작성하고 url에서 해쉬정보를 추출해 페이지를 이동하는 라우터 기능을 만들었다.

## style
스타일을 적용해 페이지 이동 시 스크롤이 top-left로 초기화 되도록 하였다.

## url 가공
url의 경로정보와 쿼리스트링을 분리하고 쿼리스트링을 가공하였다.

url의 해쉬를 통해 정보를 받아 가공하고 
원하는 페이지로 이동하도록 하였다. 
history 기능을 통해 url에 hash정보가 없을 대 기본값을 설정하도록 하였다. 
route기능을 초기화하는 index,js를 만들고, 
router에서 해당 페이지를 읽고 화면에 출력하도록 하였다.
